### PR TITLE
fix: only alert on HIGH/CRITICAL risk

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1486,10 +1486,9 @@ async function sendAlert(activity, risk) {
   if (!alertConfig.enabled || !alertConfig.webhookUrl) return;
   
   // Check if we should alert on this
-  if (alertConfig.alertOnHighRisk && risk.level !== 'high') {
-    if (!alertConfig.alertOnCategories.includes(categorize(activity.tool))) {
-      return;
-    }
+  // Only alert if the risk level is in the configured onRiskLevels list (e.g. ['high', 'critical'])
+  if (!alertConfig.onRiskLevels.includes(risk.level)) {
+    return;
   }
   
   const payload = {


### PR DESCRIPTION
This PR fixes a bug where alerts were being sent for LOW risk events or potentially missing CRITICAL events. The logic now strictly adheres to the configured `onRiskLevels` (defaulting to HIGH/CRITICAL).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated alert logic to evaluate risk levels against a configured list for improved consistency in alert triggering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->